### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :move_to_index, except: [:index, :show]
 
   def index
-    #@items = Item.all
+    @items = Item.all
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :move_to_index, except: [:index, :show]
 
   def index
-    @items = Item.all
+    @items = Item.all.order('created_at DESC')
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,31 +1,30 @@
 class Item < ApplicationRecord
-   extend ActiveHash::Associations::ActiveRecordExtensions
-    has_one_attached :image
-    belongs_to_active_hash :category
-    belongs_to_active_hash :product_condition
-    belongs_to_active_hash :shipping_charge
-    belongs_to_active_hash :shipping_area
-    belongs_to_active_hash :days_to_ship
-    belongs_to :user
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  has_one_attached :image
+  belongs_to_active_hash :category
+  belongs_to_active_hash :product_condition
+  belongs_to_active_hash :shipping_charge
+  belongs_to_active_hash :shipping_area
+  belongs_to_active_hash :days_to_ship
+  belongs_to :user
 
-
-   with_options numericality: { other_than: 1 } do
+  with_options numericality: { other_than: 1 } do
     validates :product_category_id
     validates :product_status_id
     validates :delivery_burden_id
     validates :prefecture_id
     validates :delivery_day_id
-   end
+  end
 
-   with_options presence: true do
-      validates :image
-      validates :product_name
-      validates :product_introduction
-      validates :product_category_id
-      validates :product_status_id
-      validates :delivery_burden_id
-      validates :prefecture_id
-      validates :delivery_day_id
-      validates :price, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 }
-   end
+  with_options presence: true do
+    validates :image
+    validates :product_name
+    validates :product_introduction
+    validates :product_category_id
+    validates :product_status_id
+    validates :delivery_burden_id
+    validates :prefecture_id
+    validates :delivery_day_id
+    validates :price, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 }
+  end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -155,9 +155,8 @@
     <% end %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
-      <%# 商品がない場合のダミー %>
       <% if @items.empty? %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -176,8 +175,6 @@
         <% end %>
       </li>
       <% end %>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# /商品がない場合のダミー %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,6 +125,7 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
+
       <% @items.each do |item|%>
       <li class='list'>
         <%= link_to items_path(item.id), method: :get do%>
@@ -140,10 +141,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.product_name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br>(税込み)</span>
+            <span><%= item.price %>円<br>(税込み)</span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,7 +127,7 @@
     <ul class='item-lists'>
 
       <% @items.each do |item|%>
-      <li class='list'>
+       <li class='list'>
         <%= link_to items_path(item.id), method: :get do%>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" if item.image.attached? %>
@@ -151,11 +151,12 @@
             </div>
           </div>
         </div>
-      </li>
-      <% end %>
+       </li>
+    <% end %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合のダミー %>
+      <% if @items.empty? %>
       <%# 商品がある場合は表示されないようにしましょう %>
       <li class='list'>
         <%= link_to '#' do %>
@@ -174,6 +175,7 @@
         </div>
         <% end %>
       </li>
+      <% end %>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# /商品がない場合のダミー %>
     </ul>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -6,9 +6,7 @@
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model: @item, local: true do |f|%>
-
     <%= render 'shared/error_messages', model: f.object %>
-
     <%# 出品画像 %>
     <div class="img-upload">
       <div class="weight-bold-text">

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -34,7 +34,7 @@ describe Item, type: :model do
       it 'カテゴリーにID1が選択されていた場合は出品できない' do
         @item.product_category_id = '1'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Product category must be other than 1")
+        expect(@item.errors.full_messages).to include('Product category must be other than 1')
       end
 
       it '商品の状態が空では出品できない' do
@@ -46,7 +46,7 @@ describe Item, type: :model do
       it '商品の状態にID1が選択されていた場合は出品できない' do
         @item.product_status_id = '1'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Product status must be other than 1")
+        expect(@item.errors.full_messages).to include('Product status must be other than 1')
       end
 
       it '配送料の負担が空では出品できない' do
@@ -58,7 +58,7 @@ describe Item, type: :model do
       it '配送料にID1が選択されていた場合は出品できない' do
         @item.delivery_burden_id = '1'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery burden must be other than 1")
+        expect(@item.errors.full_messages).to include('Delivery burden must be other than 1')
       end
 
       it '配送元の地域が空では出品できない' do
@@ -70,7 +70,7 @@ describe Item, type: :model do
       it '配送元にID1が選択されていた場合は出品できない' do
         @item.prefecture_id = '1'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Prefecture must be other than 1")
+        expect(@item.errors.full_messages).to include('Prefecture must be other than 1')
       end
 
       it '発送までの日数が空では出品できない' do
@@ -82,7 +82,7 @@ describe Item, type: :model do
       it '発送までの日数にID1が選択されていた場合は出品できない' do
         @item.delivery_day_id = '1'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery day must be other than 1")
+        expect(@item.errors.full_messages).to include('Delivery day must be other than 1')
       end
 
       it '価格が空では出品できない' do
@@ -100,15 +100,14 @@ describe Item, type: :model do
       it '価格299円以下では出品できない' do
         @item.price = '299'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price must be greater than or equal to 300")
+        expect(@item.errors.full_messages).to include('Price must be greater than or equal to 300')
       end
 
       it '価格10,000,000円以上では出品できない' do
         @item.price = '10000000'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price must be less than or equal to 9999999")
+        expect(@item.errors.full_messages).to include('Price must be less than or equal to 9999999')
       end
-
 
       it '商品画像が空では出品できない' do
         @item.image = nil


### PR DESCRIPTION
お疲れ様です。商品一覧表示機能を実装したので確認をお願いします

# What
出品した商品の一覧表示ができていること
上から、出品された日時が新しい順に表示されること
「画像/価格/商品名」の3つの情報について表示できていること
売却済みの商品は、画像上に「sold out」の文字が表示されるようになっていること
ログアウト状態のユーザーでも、商品一覧表示ページを見ることができること
# Why
商品を表示することによりユーザーに対しどのような物が売られているか確認できる為、実装しました

機能確認動画
https://gyazo.com/3737bb71135d490a03d4a54f2c1f9f06