### PR TITLE
商品詳細機能実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -6,7 +6,11 @@ class ItemsController < ApplicationController
   end
 
   def new
-    @item = Item.new
+    if user_signed_in?
+      @item = Item.new
+    else
+      redirect_to user_session_path
+    end
   end
 
   def create
@@ -16,6 +20,10 @@ class ItemsController < ApplicationController
     else
       render :new
     end
+  end
+
+  def show
+    @item = Item.find(params[:id])
   end
 
   private

--- a/app/models/delivery_burden.rb
+++ b/app/models/delivery_burden.rb
@@ -1,4 +1,4 @@
-class ShippingCharge < ActiveHash::Base
+class DeliveryBurden < ActiveHash::Base
   self.data = [
     { id: 1, name: '--' },
     { id: 2, name: '着払い(購入者負担)' },

--- a/app/models/delivery_day.rb
+++ b/app/models/delivery_day.rb
@@ -1,4 +1,4 @@
-class DaysToShip < ActiveHash::Base
+class DeliveryDay < ActiveHash::Base
   self.data = [
     { id: 1, name: '--' },
     { id: 2, name: '1~2日で発送' },

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,11 +1,11 @@
 class Item < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
   has_one_attached :image
-  belongs_to_active_hash :category
-  belongs_to_active_hash :product_condition
-  belongs_to_active_hash :shipping_charge
-  belongs_to_active_hash :shipping_area
-  belongs_to_active_hash :days_to_ship
+  belongs_to_active_hash :product_category
+  belongs_to_active_hash :product_status
+  belongs_to_active_hash :delivery_burden
+  belongs_to_active_hash :prefecture
+  belongs_to_active_hash :delivery_day
   belongs_to :user
 
   with_options numericality: { other_than: 1 } do

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -1,4 +1,4 @@
-class ShippingArea < ActiveHash::Base
+class Prefecture < ActiveHash::Base
   self.data = [
     { id: 1, name: '--' },
     { id: 2, name: '北海道' }, { id: 3, name: '青森県' }, { id: 4, name: '岩手県' },

--- a/app/models/product_category.rb
+++ b/app/models/product_category.rb
@@ -1,4 +1,4 @@
-class Category < ActiveHash::Base
+class ProductCategory < ActiveHash::Base
   self.data = [
     { id: 1, name: '--' },
     { id: 2, name: 'レディース' },

--- a/app/models/product_status.rb
+++ b/app/models/product_status.rb
@@ -1,4 +1,4 @@
-class ProductCondition < ActiveHash::Base
+class ProductStatus < ActiveHash::Base
   self.data = [
     { id: 1, name: '--' },
     { id: 2, name: '新品、未使用' },

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,12 +123,12 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <%= link_to '新規投稿商品', "#", class: "subtitle" %>
+    <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
 
       <% @items.each do |item|%>
        <li class='list'>
-        <%= link_to items_path(item.id), method: :get do%>
+        <%= link_to item_path(item.id), method: :get do%>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" if item.image.attached? %>
          <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,11 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.product_name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" if @item.image.attached? %>
+
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -24,15 +25,17 @@
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
+    <% if user_signed_in? %>
+      <% if current_user.id == @item.user_id %>
+      <%= link_to '商品の編集', item_path, method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+      <% elsif %>
+        <%# 商品が売れていない場合はこちらを表示しましょう %>
+        <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+        <%# //商品が売れていない場合はこちらを表示しましょう %>
+      <% end %>
+    <% end %>
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
@@ -43,27 +46,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.product_category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.product_status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.delivery_burden.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.delivery_day.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -17,30 +17,27 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price %>
       </span>
       <span class="item-postage">
         (税込) 送料込み
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+
     <% if user_signed_in? %>
       <% if current_user.id == @item.user_id %>
       <%= link_to '商品の編集', item_path, method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
       <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
       <% elsif %>
-        <%# 商品が売れていない場合はこちらを表示しましょう %>
         <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-        <%# //商品が売れていない場合はこちらを表示しましょう %>
       <% end %>
     <% end %>
 
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.product_introduction %></span>
     </div>
     <table class="detail-table">
       <tbody>
@@ -105,7 +102,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.product_category_id %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -30,7 +30,7 @@
       <%= link_to '商品の編集', item_path, method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
       <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-      <% elsif %>
+      <% else %>
         <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
       <% end %>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:new, :index, :create]
+  resources :items, only: [:new, :index, :create, :show]
 end


### PR DESCRIPTION
お疲れ様です。商品詳細機能を実装したので確認お願いします

# What
ログイン状態の出品者のみ、「編集・削除ボタン」が表示されること
ログイン状態の出品者でも、売却済みの商品に対しては「編集・削除ボタン」が表示されないこと
ログイン状態の出品者以外のユーザーのみ、「購入画面に進むボタン」が表示されること
ログアウト状態のユーザーでも、商品詳細表示ページを閲覧できること
ログアウト状態のユーザーには、「編集・削除・購入画面に進むボタン」が表示されないこと
商品出品時に登録した情報が見られるようになっていること
画像が表示されており、画像がリンク切れなどになっていないこと（Herokuの仕様による画像のリンク切れは、要件未達に含まれない。デプロイのタスクにあるとおり、Heroku上では一定時間経過すると画像が消える。）
売却済みの商品は、画像上に「sold out」の文字が表示されるようになっていること

# Why
ログインの有無による設定を行うことでより不備なくアプリケーションを運用するとこができる為

機能確認動画
未ログイン時の詳細画面
https://gyazo.com/918f497732ac71988f48d700729ac209
出品者の詳細画面
https://gyazo.com/c7e81c82f5afb6794de4f817d58c1cb6
別ユーザーの詳細画面
https://gyazo.com/93a33092824a37126edadc7dc37bce20